### PR TITLE
Mediate all access to CoreBluetooth objects through a serial dispatch queue

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -37,7 +37,7 @@ impl Adapter {
 
     /// A stream of [`AdapterEvent`] which allows the application to identify when the adapter is enabled or disabled.
     #[inline]
-    pub async fn events(&self) -> Result<impl Stream<Item = Result<AdapterEvent>> + Unpin + '_> {
+    pub async fn events(&self) -> Result<impl Stream<Item = Result<AdapterEvent>> + Send + Unpin + '_> {
         self.0.events().await
     }
 
@@ -87,7 +87,7 @@ impl Adapter {
     pub async fn scan<'a>(
         &'a self,
         services: &'a [Uuid],
-    ) -> Result<impl Stream<Item = AdvertisingDevice> + Unpin + 'a> {
+    ) -> Result<impl Stream<Item = AdvertisingDevice> + Send + Unpin + 'a> {
         self.0.scan(services).await
     }
 
@@ -101,7 +101,7 @@ impl Adapter {
     pub async fn discover_devices<'a>(
         &'a self,
         services: &'a [Uuid],
-    ) -> Result<impl Stream<Item = Result<Device>> + Unpin + 'a> {
+    ) -> Result<impl Stream<Item = Result<Device>> + Send + Unpin + 'a> {
         self.0.discover_devices(services).await
     }
 
@@ -170,7 +170,7 @@ impl Adapter {
     pub async fn device_connection_events<'a>(
         &'a self,
         device: &'a Device,
-    ) -> Result<impl Stream<Item = ConnectionEvent> + Unpin + 'a> {
+    ) -> Result<impl Stream<Item = ConnectionEvent> + Send + Unpin + 'a> {
         self.0.device_connection_events(device).await
     }
 }

--- a/src/characteristic.rs
+++ b/src/characteristic.rs
@@ -77,7 +77,7 @@ impl Characteristic {
     ///
     /// Returns a stream of values for the characteristic sent from the device.
     #[inline]
-    pub async fn notify(&self) -> Result<impl Stream<Item = Result<Vec<u8>>> + Unpin + '_> {
+    pub async fn notify(&self) -> Result<impl Stream<Item = Result<Vec<u8>>> + Send + Unpin + '_> {
         self.0.notify().await
     }
 

--- a/src/corebluetooth.rs
+++ b/src/corebluetooth.rs
@@ -12,7 +12,9 @@ pub mod error;
 pub mod l2cap_channel;
 pub mod service;
 
+mod ad;
 pub(crate) mod delegates;
+pub(crate) mod dispatch;
 
 /// A platform-specific device identifier.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/src/corebluetooth/ad.rs
+++ b/src/corebluetooth/ad.rs
@@ -1,0 +1,90 @@
+use std::collections::HashMap;
+
+use objc2_core_bluetooth::{
+    CBAdvertisementDataIsConnectable, CBAdvertisementDataLocalNameKey,
+    CBAdvertisementDataManufacturerDataKey, CBAdvertisementDataOverflowServiceUUIDsKey,
+    CBAdvertisementDataServiceDataKey, CBAdvertisementDataServiceUUIDsKey,
+    CBAdvertisementDataTxPowerLevelKey, CBUUID,
+};
+use objc2_foundation::{NSArray, NSData, NSDictionary, NSNumber, NSString};
+use uuid::Uuid;
+
+use crate::{AdvertisementData, BluetoothUuidExt, ManufacturerData};
+
+impl AdvertisementData {
+    pub(crate) fn from_nsdictionary(adv_data: &NSDictionary<NSString>) -> Self {
+        let is_connectable = adv_data
+            .objectForKey(unsafe { CBAdvertisementDataIsConnectable })
+            .is_some_and(|val| {
+                val.downcast_ref::<NSNumber>()
+                    .map(|b| b.as_bool())
+                    .unwrap_or(false)
+            });
+
+        let local_name = adv_data
+            .objectForKey(unsafe { CBAdvertisementDataLocalNameKey })
+            .and_then(|val| val.downcast_ref::<NSString>().map(|s| s.to_string()));
+
+        let manufacturer_data = adv_data
+            .objectForKey(unsafe { CBAdvertisementDataManufacturerDataKey })
+            .and_then(|val| val.downcast_ref::<NSData>().map(|v| v.to_vec()))
+            .and_then(|val| {
+                (val.len() >= 2).then(|| ManufacturerData {
+                    company_id: u16::from_le_bytes(val[0..2].try_into().unwrap()),
+                    data: val[2..].to_vec(),
+                })
+            });
+
+        let tx_power_level: Option<i16> = adv_data
+            .objectForKey(unsafe { CBAdvertisementDataTxPowerLevelKey })
+            .and_then(|val| val.downcast_ref::<NSNumber>().map(|val| val.shortValue()));
+
+        let service_data = if let Some(val) =
+            adv_data.objectForKey(unsafe { CBAdvertisementDataServiceDataKey })
+        {
+            unsafe {
+                if let Some(val) = val.downcast_ref::<NSDictionary>() {
+                    let mut res = HashMap::with_capacity(val.count());
+                    for k in val.allKeys() {
+                        if let Some(key) = k.downcast_ref::<CBUUID>() {
+                            if let Some(val) = val
+                                .objectForKey_unchecked(&k)
+                                .and_then(|val| val.downcast_ref::<NSData>())
+                            {
+                                res.insert(
+                                    Uuid::from_bluetooth_bytes(key.data().as_bytes_unchecked()),
+                                    val.to_vec(),
+                                );
+                            }
+                        }
+                    }
+                    res
+                } else {
+                    HashMap::new()
+                }
+            }
+        } else {
+            HashMap::new()
+        };
+
+        let services = adv_data
+            .objectForKey(unsafe { CBAdvertisementDataServiceUUIDsKey })
+            .into_iter()
+            .chain(adv_data.objectForKey(unsafe { CBAdvertisementDataOverflowServiceUUIDsKey }))
+            .flat_map(|x| x.downcast::<NSArray>())
+            .flatten()
+            .flat_map(|obj| obj.downcast::<CBUUID>())
+            .map(|uuid| unsafe { uuid.data() })
+            .map(|data| unsafe { Uuid::from_bluetooth_bytes(data.as_bytes_unchecked()) })
+            .collect();
+
+        AdvertisementData {
+            local_name,
+            manufacturer_data,
+            services,
+            service_data,
+            tx_power_level,
+            is_connectable,
+        }
+    }
+}

--- a/src/corebluetooth/adapter.rs
+++ b/src/corebluetooth/adapter.rs
@@ -1,40 +1,33 @@
 #![allow(clippy::let_unit_value)]
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use dispatch2::{DispatchQoS, DispatchQueue, GlobalQueueIdentifier};
 use futures_core::Stream;
-use futures_lite::{StreamExt, stream};
-use objc2::AnyThread;
+use futures_lite::{stream, StreamExt};
 use objc2::rc::Retained;
 use objc2::runtime::ProtocolObject;
+use objc2::AnyThread;
 use objc2_core_bluetooth::{
-    CBAdvertisementDataIsConnectable, CBAdvertisementDataLocalNameKey,
-    CBAdvertisementDataManufacturerDataKey, CBAdvertisementDataOverflowServiceUUIDsKey,
-    CBAdvertisementDataServiceDataKey, CBAdvertisementDataServiceUUIDsKey,
-    CBAdvertisementDataTxPowerLevelKey, CBCentralManager, CBManager, CBManagerAuthorization,
-    CBManagerState, CBUUID,
+    CBCentralManager, CBManager, CBManagerAuthorization, CBManagerState, CBUUID,
 };
-use objc2_foundation::{NSArray, NSData, NSDictionary, NSNumber, NSString, NSUUID};
+use objc2_foundation::{NSArray, NSData, NSUUID};
 use tracing::{debug, error, info, warn};
 
 use super::delegates::{self, CentralDelegate};
-use crate::ManufacturerData;
+use super::dispatch::{self, Dispatched};
 use crate::error::ErrorKind;
 use crate::util::defer;
 use crate::{
-    AdapterEvent, AdvertisementData, AdvertisingDevice, ConnectionEvent, Device, DeviceId, Error,
-    Result, Uuid,
+    AdapterEvent, AdvertisingDevice, ConnectionEvent, Device, DeviceId, Error, Result, Uuid,
 };
-use std::collections::HashMap;
 
 /// The system's Bluetooth adapter interface.
 ///
 /// The default adapter for the system may be accessed with the [`Adapter::default()`] method.
 #[derive(Clone)]
 pub struct AdapterImpl {
-    central: Retained<CBCentralManager>,
+    central: Dispatched<CBCentralManager>,
     delegate: Retained<CentralDelegate>,
     scanning: Arc<AtomicBool>,
     #[cfg(not(target_os = "macos"))]
@@ -77,13 +70,11 @@ impl AdapterImpl {
         let delegate = CentralDelegate::new();
         let protocol = ProtocolObject::from_retained(delegate.clone());
         let central = unsafe {
-            let queue = DispatchQueue::global_queue(GlobalQueueIdentifier::QualityOfService(
-                DispatchQoS::Utility,
-            ));
             let this = CBCentralManager::alloc();
             // let options = NSDictionary::from_slices(&[CBCentralManagerOptionShowPowerAlertKey], &[NSNumber::numberWithBool(config.request_permissions)]);
-            CBCentralManager::initWithDelegate_queue(this, Some(&protocol), Some(&queue))
+            CBCentralManager::initWithDelegate_queue(this, Some(&protocol), Some(dispatch::queue()))
         };
+        let central = unsafe { Dispatched::new(central) };
 
         Some(AdapterImpl {
             central,
@@ -101,7 +92,7 @@ impl AdapterImpl {
             match x {
                 delegates::CentralEvent::StateChanged => {
                     // TODO: Check CBCentralManager::authorization()?
-                    let state = unsafe { self.central.state() };
+                    let state = self.central.dispatch(|central| unsafe { central.state() });
                     debug!("Central state is now {:?}", state);
                     match state {
                         CBManagerState::PoweredOn => Some(Ok(AdapterEvent::Available)),
@@ -113,11 +104,15 @@ impl AdapterImpl {
         }))
     }
 
+    fn state(&self) -> CBManagerState {
+        self.central.dispatch(|central| unsafe { central.state() })
+    }
+
     /// Check if the adapter is available.
     ///
     /// If the state is not known, assume that it's available.
     pub fn is_available(&self) -> bool {
-        let state = unsafe { self.central.state() };
+        let state = self.state();
         info!("state: {:?}", state);
         state == CBManagerState::PoweredOn || state == CBManagerState::Unknown
     }
@@ -125,7 +120,7 @@ impl AdapterImpl {
     /// Asynchronously blocks until the adapter is available
     pub async fn wait_available(&self) -> Result<()> {
         let events = self.events();
-        if unsafe { self.central.state() } != CBManagerState::PoweredOn {
+        if self.state() != CBManagerState::PoweredOn {
             events
                 .await?
                 .skip_while(|x| x.is_ok() && !matches!(x, Ok(AdapterEvent::Available)))
@@ -144,17 +139,16 @@ impl AdapterImpl {
 
     /// Attempts to create the device identified by `id`
     pub async fn open_device(&self, id: &DeviceId) -> Result<Device> {
-        let identifiers = NSArray::from_retained_slice(&[NSUUID::from_bytes(*id.0.as_bytes())]);
-        let peripherals = unsafe {
-            self.central
-                .retrievePeripheralsWithIdentifiers(&identifiers)
-        };
+        self.central.dispatch(|central| unsafe {
+            let identifiers = NSArray::from_retained_slice(&[NSUUID::from_bytes(*id.0.as_bytes())]);
+            let peripherals = central.retrievePeripheralsWithIdentifiers(&identifiers);
 
-        peripherals
-            .iter()
-            .next()
-            .map(|x| Device::new(x))
-            .ok_or_else(|| Error::new(ErrorKind::NotFound, None, "opening device"))
+            peripherals
+                .iter()
+                .next()
+                .map(|x| Device::new(Dispatched::new(x)))
+                .ok_or_else(|| Error::new(ErrorKind::NotFound, None, "opening device"))
+        })
     }
 
     /// Finds all connected Bluetooth LE devices
@@ -171,20 +165,25 @@ impl AdapterImpl {
     pub async fn connected_devices_with_services(&self, services: &[Uuid]) -> Result<Vec<Device>> {
         assert!(!services.is_empty());
 
-        let services = {
-            let vec = services
-                .iter()
-                .copied()
-                .map(|s| unsafe { CBUUID::UUIDWithData(&NSData::with_bytes(&s.as_bytes()[..])) })
-                .collect::<Vec<_>>();
-            NSArray::from_retained_slice(&vec[..])
-        };
-        unsafe {
-            let peripherals = self
-                .central
-                .retrieveConnectedPeripheralsWithServices(&services);
-            Ok(peripherals.iter().map(|x| Device::new(x)).collect())
-        }
+        self.central.dispatch(|central| {
+            let services = {
+                let vec = services
+                    .iter()
+                    .copied()
+                    .map(|s| unsafe {
+                        CBUUID::UUIDWithData(&NSData::with_bytes(&s.as_bytes()[..]))
+                    })
+                    .collect::<Vec<_>>();
+                NSArray::from_retained_slice(&vec[..])
+            };
+            unsafe {
+                let peripherals = central.retrieveConnectedPeripheralsWithServices(&services);
+                Ok(peripherals
+                    .iter()
+                    .map(|x| Device::new(Dispatched::new(x)))
+                    .collect())
+            }
+        })
     }
 
     /// Starts scanning for Bluetooth advertising packets.
@@ -199,33 +198,38 @@ impl AdapterImpl {
         &'a self,
         services: &'a [Uuid],
     ) -> Result<impl Stream<Item = AdvertisingDevice> + Unpin + 'a> {
-        if unsafe { self.central.state() } != CBManagerState::PoweredOn {
-            return Err(ErrorKind::AdapterUnavailable.into());
+        if self.state() != CBManagerState::PoweredOn {
+            return Err(Error::from(ErrorKind::AdapterUnavailable));
         }
 
         if self.scanning.swap(true, Ordering::Acquire) {
             return Err(ErrorKind::AlreadyScanning.into());
         }
 
-        let services = (!services.is_empty()).then(|| {
-            let vec = services
-                .iter()
-                .copied()
-                .map(|s| unsafe { CBUUID::UUIDWithData(&NSData::with_bytes(&s.as_bytes()[..])) })
-                .collect::<Vec<_>>();
-            NSArray::from_retained_slice(&vec[..])
+        let receiver = self.delegate.sender().new_receiver();
+        self.central.dispatch(|central| {
+            let services = (!services.is_empty()).then(|| {
+                let vec = services
+                    .iter()
+                    .copied()
+                    .map(|s| unsafe {
+                        CBUUID::UUIDWithData(&NSData::with_bytes(&s.as_bytes()[..]))
+                    })
+                    .collect::<Vec<_>>();
+                NSArray::from_retained_slice(&vec[..])
+            });
+
+            unsafe { central.scanForPeripheralsWithServices_options(services.as_deref(), None) };
         });
 
         let guard = defer(|| {
-            unsafe { self.central.stopScan() };
+            self.central
+                .dispatch(|central| unsafe { central.stopScan() });
             self.scanning.store(false, Ordering::Release);
         });
 
-        let events = self
-            .delegate
-            .sender()
-            .new_receiver()
-            .take_while(|_| unsafe { self.central.state() } == CBManagerState::PoweredOn)
+        let events = receiver
+            .take_while(|_| self.state() == CBManagerState::PoweredOn)
             .filter_map(move |x| {
                 let _guard = &guard;
                 match x {
@@ -235,17 +239,12 @@ impl AdapterImpl {
                         rssi,
                     } => Some(AdvertisingDevice {
                         device: Device::new(peripheral),
-                        adv_data: AdvertisementData::from_nsdictionary(&adv_data),
+                        adv_data,
                         rssi: Some(rssi),
                     }),
                     _ => None,
                 }
             });
-
-        unsafe {
-            self.central
-                .scanForPeripheralsWithServices_options(services.as_deref(), None)
-        };
 
         Ok(events)
     }
@@ -281,18 +280,18 @@ impl AdapterImpl {
     /// exist) and the application can then interact with the device. This connection will be maintained until either
     /// [`disconnect_device`][Self::disconnect_device] is called or the `Adapter` is dropped.
     pub async fn connect_device(&self, device: &Device) -> Result<()> {
-        if unsafe { self.central.state() } != CBManagerState::PoweredOn {
+        if self.state() != CBManagerState::PoweredOn {
             return Err(ErrorKind::AdapterUnavailable.into());
         }
 
         let mut events = self.delegate.sender().new_receiver();
         debug!("Connecting to {:?}", device);
-        unsafe {
-            self.central
-                .connectPeripheral_options(&device.0.peripheral, None)
-        };
+        self.central.dispatch(|central| unsafe {
+            central.connectPeripheral_options(device.0.peripheral.get(), None)
+        });
+
         while let Some(event) = events.next().await {
-            if unsafe { self.central.state() } != CBManagerState::PoweredOn {
+            if self.state() != CBManagerState::PoweredOn {
                 return Err(ErrorKind::AdapterUnavailable.into());
             }
             match event {
@@ -321,18 +320,17 @@ impl AdapterImpl {
     /// which would require a connection will fail. If no other application has a connection to the same device,
     /// the underlying Bluetooth connection will be closed.
     pub async fn disconnect_device(&self, device: &Device) -> Result<()> {
-        if unsafe { self.central.state() } != CBManagerState::PoweredOn {
+        if self.state() != CBManagerState::PoweredOn {
             return Err(ErrorKind::AdapterUnavailable.into());
         }
 
         let mut events = self.delegate.sender().new_receiver();
         debug!("Disconnecting from {:?}", device);
-        unsafe {
-            self.central
-                .cancelPeripheralConnection(&device.0.peripheral)
-        };
+        self.central.dispatch(|central| unsafe {
+            central.cancelPeripheralConnection(device.0.peripheral.get())
+        });
         while let Some(event) = events.next().await {
-            if unsafe { self.central.state() } != CBManagerState::PoweredOn {
+            if self.state() != CBManagerState::PoweredOn {
                 return Err(ErrorKind::AdapterUnavailable.into());
             }
             match event {
@@ -356,10 +354,8 @@ impl AdapterImpl {
         use std::collections::HashMap;
 
         use objc2::rc::Retained;
-        use objc2_core_bluetooth::CBConnectionEventMatchingOptionServiceUUIDs;
+        use objc2_core_bluetooth::CBConnectionEventMatchingOptionPeripheralUUIDs;
         use objc2_foundation::{NSDictionary, NSString};
-
-        let mut guard = self.registered_connection_events.lock().unwrap();
 
         fn options(devices: &HashMap<DeviceId, usize>) -> Retained<NSDictionary<NSString>> {
             let ids: Vec<Retained<CBUUID>> = devices
@@ -368,41 +364,41 @@ impl AdapterImpl {
                 .collect();
             let ids = NSArray::from_retained_slice(&ids[..]);
             NSDictionary::from_retained_objects(
-                &[unsafe { CBConnectionEventMatchingOptionServiceUUIDs }],
+                &[unsafe { CBConnectionEventMatchingOptionPeripheralUUIDs }],
                 &[ids.into()],
             )
         }
 
-        match guard.entry(device.clone()) {
-            std::collections::hash_map::Entry::Occupied(mut e) => {
-                *e.get_mut() += 1;
-            }
-            std::collections::hash_map::Entry::Vacant(e) => {
-                e.insert(1);
-                let opts = options(&guard);
-                unsafe {
-                    self.central
-                        .registerForConnectionEventsWithOptions(Some(&opts))
+        self.central.dispatch(|central| {
+            let mut guard = self.registered_connection_events.lock().unwrap();
+
+            match guard.entry(device.clone()) {
+                std::collections::hash_map::Entry::Occupied(mut e) => {
+                    *e.get_mut() += 1;
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(1);
+                    let opts = options(&guard);
+                    unsafe { central.registerForConnectionEventsWithOptions(Some(&opts)) }
                 }
             }
-        }
+        });
 
         defer(move || {
-            let mut guard = self.registered_connection_events.lock().unwrap();
-            match guard.entry(device) {
-                std::collections::hash_map::Entry::Occupied(mut e) => {
-                    *e.get_mut() -= 1;
-                    if *e.get() == 0 {
-                        e.remove();
-                        let opts = options(&guard);
-                        unsafe {
-                            self.central
-                                .registerForConnectionEventsWithOptions(Some(&opts))
+            self.central.dispatch(|central| {
+                let mut guard = self.registered_connection_events.lock().unwrap();
+                match guard.entry(device) {
+                    std::collections::hash_map::Entry::Occupied(mut e) => {
+                        *e.get_mut() -= 1;
+                        if *e.get() == 0 {
+                            e.remove();
+                            let opts = options(&guard);
+                            unsafe { central.registerForConnectionEventsWithOptions(Some(&opts)) }
                         }
                     }
+                    std::collections::hash_map::Entry::Vacant(_) => unreachable!(),
                 }
-                std::collections::hash_map::Entry::Vacant(_) => unreachable!(),
-            }
+            })
         })
     }
 
@@ -421,22 +417,25 @@ impl AdapterImpl {
         let events = self.delegate.sender().new_receiver();
         let guard = self.register_connection_events(device.id());
 
+        let id = device
+            .0
+            .peripheral
+            .dispatch(|peripheral| unsafe { peripheral.identifier() });
+
         Ok(events
-            .take_while(|_| unsafe { self.central.state() } == CBManagerState::PoweredOn)
+            .take_while(|_| self.state() == CBManagerState::PoweredOn)
             .filter_map(move |x| {
                 let _guard = &guard;
                 match x {
                     delegates::CentralEvent::Connect { peripheral }
-                        if unsafe {
-                            peripheral.identifier() == device.0.peripheral.identifier()
-                        } =>
+                        if peripheral
+                            .dispatch(|peripheral| unsafe { peripheral.identifier() } == id) =>
                     {
                         Some(ConnectionEvent::Connected)
                     }
                     delegates::CentralEvent::Disconnect { peripheral, .. }
-                        if unsafe {
-                            peripheral.identifier() == device.0.peripheral.identifier()
-                        } =>
+                        if peripheral
+                            .dispatch(|peripheral| unsafe { peripheral.identifier() } == id) =>
                     {
                         Some(ConnectionEvent::Disconnected)
                     }
@@ -459,7 +458,7 @@ impl AdapterImpl {
     ) -> Result<impl Stream<Item = ConnectionEvent> + Unpin + 'a> {
         let events = self.delegate.sender().new_receiver();
         Ok(events
-            .take_while(|_| unsafe { self.central.state() } == CBManagerState::PoweredOn)
+            .take_while(|_| self.state() == CBManagerState::PoweredOn)
             .filter_map(move |x| match x {
                 delegates::CentralEvent::Connect { peripheral }
                     if peripheral == device.0.peripheral =>
@@ -473,88 +472,5 @@ impl AdapterImpl {
                 }
                 _ => None,
             }))
-    }
-}
-
-impl AdvertisementData {
-    fn from_nsdictionary(adv_data: &Retained<NSDictionary<NSString>>) -> Self {
-        let is_connectable = adv_data
-            .objectForKey(unsafe { CBAdvertisementDataIsConnectable })
-            .is_some_and(|val| {
-                val.downcast_ref::<NSNumber>()
-                    .map(|b| b.as_bool())
-                    .unwrap_or(false)
-            });
-
-        let local_name = adv_data
-            .objectForKey(unsafe { CBAdvertisementDataLocalNameKey })
-            .map(|val| val.downcast_ref::<NSString>().map(|s| s.to_string()))
-            .flatten();
-
-        let manufacturer_data = adv_data
-            .objectForKey(unsafe { CBAdvertisementDataManufacturerDataKey })
-            .map(|val| val.downcast_ref::<NSData>().map(|v| v.to_vec()))
-            .flatten()
-            .and_then(|val| {
-                (val.len() >= 2).then(|| ManufacturerData {
-                    company_id: u16::from_le_bytes(val[0..2].try_into().unwrap()),
-                    data: val[2..].to_vec(),
-                })
-            });
-
-        let tx_power_level: Option<i16> = adv_data
-            .objectForKey(unsafe { CBAdvertisementDataTxPowerLevelKey })
-            .map(|val| val.downcast_ref::<NSNumber>().map(|val| val.shortValue()))
-            .flatten();
-
-        let service_data = if let Some(val) =
-            adv_data.objectForKey(unsafe { CBAdvertisementDataServiceDataKey })
-        {
-            unsafe {
-                if let Some(val) = val.downcast_ref::<NSDictionary>() {
-                    let mut res = HashMap::with_capacity(val.count());
-                    for k in val.allKeys() {
-                        if let Some(key) = k.downcast_ref::<CBUUID>() {
-                            if let Some(val) = val
-                                .objectForKey_unchecked(&k)
-                                .map(|val| val.downcast_ref::<NSData>())
-                                .flatten()
-                            {
-                                res.insert(
-                                    Uuid::from_slice(key.data().as_bytes_unchecked()).unwrap(),
-                                    val.to_vec(),
-                                );
-                            }
-                        }
-                    }
-                    res
-                } else {
-                    HashMap::new()
-                }
-            }
-        } else {
-            HashMap::new()
-        };
-
-        let services = adv_data
-            .objectForKey(unsafe { CBAdvertisementDataServiceUUIDsKey })
-            .into_iter()
-            .chain(adv_data.objectForKey(unsafe { CBAdvertisementDataOverflowServiceUUIDsKey }))
-            .flat_map(|x| x.downcast::<NSArray>())
-            .flatten()
-            .map(|obj| obj.downcast::<CBUUID>())
-            .flatten()
-            .map(|uuid| unsafe { uuid.data() })
-            .map(|data| unsafe { Uuid::from_slice(data.as_bytes_unchecked()).unwrap() })
-            .collect();
-
-        AdvertisementData {
-            local_name,
-            manufacturer_data,
-            services,
-            service_data,
-            tx_power_level,
-            is_connectable,
-        }
     }
 }

--- a/src/corebluetooth/characteristic.rs
+++ b/src/corebluetooth/characteristic.rs
@@ -1,13 +1,15 @@
 use futures_core::Stream;
 use futures_lite::StreamExt;
-use objc2::Message;
 use objc2::rc::Retained;
 use objc2_foundation::NSData;
 
 use super::delegates::{PeripheralDelegate, PeripheralEvent};
+use super::dispatch::Dispatched;
 use crate::error::ErrorKind;
 use crate::util::defer;
-use crate::{Characteristic, CharacteristicProperties, Descriptor, Error, Result, Uuid};
+use crate::{
+    BluetoothUuidExt, Characteristic, CharacteristicProperties, Descriptor, Error, Result, Uuid,
+};
 use objc2_core_bluetooth::{
     CBCharacteristic, CBCharacteristicProperties, CBCharacteristicWriteType, CBPeripheralState,
 };
@@ -15,17 +17,17 @@ use objc2_core_bluetooth::{
 /// A Bluetooth GATT characteristic
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct CharacteristicImpl {
-    inner: Retained<CBCharacteristic>,
+    inner: Dispatched<CBCharacteristic>,
     delegate: Retained<PeripheralDelegate>,
 }
 
 impl Characteristic {
     pub(super) fn new(
-        characteristic: &CBCharacteristic,
+        characteristic: Retained<CBCharacteristic>,
         delegate: Retained<PeripheralDelegate>,
     ) -> Self {
         Characteristic(CharacteristicImpl {
-            inner: characteristic.retain(),
+            inner: unsafe { Dispatched::new(characteristic) },
             delegate,
         })
     }
@@ -34,7 +36,9 @@ impl Characteristic {
 impl CharacteristicImpl {
     /// The [`Uuid`] identifying the type of this GATT characteristic
     pub fn uuid(&self) -> Uuid {
-        unsafe { Uuid::from_slice(self.inner.UUID().data().as_bytes_unchecked()).unwrap() }
+        self.inner.dispatch(|characteristic| unsafe {
+            Uuid::from_bluetooth_bytes(characteristic.UUID().data().as_bytes_unchecked())
+        })
     }
 
     /// The [`Uuid`] identifying the type of this GATT characteristic
@@ -47,22 +51,36 @@ impl CharacteristicImpl {
     /// Characteristic properties indicate which operations (e.g. read, write, notify, etc) may be performed on this
     /// characteristic.
     pub async fn properties(&self) -> Result<CharacteristicProperties> {
+        let cb_props = self
+            .inner
+            .dispatch(|characteristic| unsafe { characteristic.properties() });
+
         let mut props = CharacteristicProperties::default();
-        match unsafe { self.inner.properties() } {
-            CBCharacteristicProperties::Broadcast => props.broadcast = true,
-            CBCharacteristicProperties::Read => props.read = true,
-            CBCharacteristicProperties::WriteWithoutResponse => props.write_without_response = true,
-            CBCharacteristicProperties::Write => props.write = true,
-            CBCharacteristicProperties::Notify => props.notify = true,
-            CBCharacteristicProperties::Indicate => props.indicate = true,
-            CBCharacteristicProperties::AuthenticatedSignedWrites => {
-                props.authenticated_signed_writes = true
-            }
-            CBCharacteristicProperties::ExtendedProperties => props.extended_properties = true,
-            CBCharacteristicProperties::NotifyEncryptionRequired => {}
-            CBCharacteristicProperties::IndicateEncryptionRequired => {}
-            _ => {}
+        if cb_props.contains(CBCharacteristicProperties::Broadcast) {
+            props.broadcast = true;
         }
+        if cb_props.contains(CBCharacteristicProperties::Read) {
+            props.read = true;
+        }
+        if cb_props.contains(CBCharacteristicProperties::WriteWithoutResponse) {
+            props.write_without_response = true;
+        }
+        if cb_props.contains(CBCharacteristicProperties::Write) {
+            props.write = true;
+        }
+        if cb_props.contains(CBCharacteristicProperties::Notify) {
+            props.notify = true;
+        }
+        if cb_props.contains(CBCharacteristicProperties::Indicate) {
+            props.indicate = true;
+        }
+        if cb_props.contains(CBCharacteristicProperties::AuthenticatedSignedWrites) {
+            props.authenticated_signed_writes = true;
+        }
+        if cb_props.contains(CBCharacteristicProperties::ExtendedProperties) {
+            props.extended_properties = true;
+        }
+
         Ok(props)
     }
 
@@ -70,8 +88,8 @@ impl CharacteristicImpl {
     ///
     /// If the value has not yet been read, this method may either return an error or perform a read of the value.
     pub async fn value(&self) -> Result<Vec<u8>> {
-        unsafe {
-            self.inner
+        self.inner.dispatch(|characteristic| unsafe {
+            characteristic
                 .value()
                 .map(|val| val.as_bytes_unchecked().to_vec())
                 .ok_or_else(|| {
@@ -81,28 +99,31 @@ impl CharacteristicImpl {
                         "the characteristic value has not been read",
                     )
                 })
-        }
+        })
     }
 
     /// Read the value of this characteristic from the device
     pub async fn read(&self) -> Result<Vec<u8>> {
-        let service = unsafe { self.inner.service() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "service not found",
-        ))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        let service = self.inner.dispatch(|characteristic| {
+            let service = unsafe { characteristic.service() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "service not found",
+            ))?;
+            let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "peripheral not found",
+            ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
 
-        unsafe { peripheral.readValueForCharacteristic(&self.inner) };
+            unsafe { peripheral.readValueForCharacteristic(characteristic) };
+            Ok(unsafe { Dispatched::new(service) })
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {
@@ -112,12 +133,7 @@ impl CharacteristicImpl {
                     error,
                 } if characteristic == self.inner => match error {
                     Some(err) => return Err(Error::from_nserror(err)),
-                    None => {
-                        let data = data
-                            .map(|val| unsafe { val.as_bytes_unchecked() }.to_vec())
-                            .unwrap_or_default();
-                        return Ok(data);
-                    }
+                    None => return Ok(data),
                 },
                 PeripheralEvent::Disconnected { error } => {
                     return Err(Error::from_kind_and_nserror(ErrorKind::NotConnected, error));
@@ -135,31 +151,35 @@ impl CharacteristicImpl {
     /// Write the value of this descriptor on the device to `value` and request the device return a response indicating
     /// a successful write.
     pub async fn write(&self, value: &[u8]) -> Result<()> {
-        let service = unsafe { self.inner.service() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "service not found",
-        ))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        let service = self.inner.dispatch(|characteristic| {
+            let service = unsafe { characteristic.service() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "service not found",
+            ))?;
+            let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "peripheral not found",
+            ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
 
-        let data = NSData::with_bytes(value);
+            let data = NSData::with_bytes(value);
 
-        unsafe {
-            peripheral.writeValue_forCharacteristic_type(
-                &data,
-                &self.inner,
-                CBCharacteristicWriteType::WithResponse,
-            )
-        };
+            unsafe {
+                peripheral.writeValue_forCharacteristic_type(
+                    &data,
+                    characteristic,
+                    CBCharacteristicWriteType::WithResponse,
+                )
+            };
+
+            Ok(unsafe { Dispatched::new(service) })
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {
@@ -185,57 +205,73 @@ impl CharacteristicImpl {
 
     /// Write the value of this descriptor on the device to `value` without requesting a response.
     pub async fn write_without_response(&self, value: &[u8]) -> Result<()> {
-        let service = unsafe { self.inner.service() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "service not found",
-        ))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        loop {
+            let service = self.inner.dispatch(|characteristic| {
+                let service = unsafe { characteristic.service() }.ok_or(Error::new(
+                    ErrorKind::NotFound,
+                    None,
+                    "service not found",
+                ))?;
+                let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                    ErrorKind::NotFound,
+                    None,
+                    "peripheral not found",
+                ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        } else if !unsafe { peripheral.canSendWriteWithoutResponse() } {
-            while let Ok(evt) = receiver.recv().await {
-                match evt {
-                    PeripheralEvent::ReadyToWrite => break,
-                    PeripheralEvent::Disconnected { error } => {
-                        return Err(Error::from_kind_and_nserror(ErrorKind::NotConnected, error));
-                    }
-                    PeripheralEvent::ServicesChanged {
-                        invalidated_services,
-                    } if invalidated_services.contains(&service) => {
-                        return Err(ErrorKind::ServiceChanged.into());
-                    }
-                    _ => (),
+                if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                    Err(Error::from(ErrorKind::NotConnected))
+                } else if unsafe { peripheral.canSendWriteWithoutResponse() } {
+                    let data = NSData::with_bytes(value);
+                    unsafe {
+                        peripheral.writeValue_forCharacteristic_type(
+                            &data,
+                            characteristic,
+                            CBCharacteristicWriteType::WithoutResponse,
+                        )
+                    };
+                    Ok(None)
+                } else {
+                    Ok(Some(unsafe { Dispatched::new(service) }))
                 }
+            })?;
+
+            if let Some(service) = service {
+                while let Ok(evt) = receiver.recv().await {
+                    match evt {
+                        PeripheralEvent::ReadyToWrite => break,
+                        PeripheralEvent::Disconnected { error } => {
+                            return Err(Error::from_kind_and_nserror(
+                                ErrorKind::NotConnected,
+                                error,
+                            ));
+                        }
+                        PeripheralEvent::ServicesChanged {
+                            invalidated_services,
+                        } if invalidated_services.contains(&service) => {
+                            return Err(ErrorKind::ServiceChanged.into());
+                        }
+                        _ => (),
+                    }
+                }
+            } else {
+                return Ok(());
             }
         }
-
-        let data = NSData::with_bytes(value);
-        unsafe {
-            peripheral.writeValue_forCharacteristic_type(
-                &data,
-                &self.inner,
-                CBCharacteristicWriteType::WithoutResponse,
-            )
-        };
-        Ok(())
     }
 
     /// Get the maximum amount of data that can be written in a single packet for this characteristic.
     pub fn max_write_len(&self) -> Result<usize> {
-        let peripheral = unsafe { self.inner.service().and_then(|x| x.peripheral()) }.ok_or(
-            Error::new(ErrorKind::NotFound, None, "peripheral not found"),
-        )?;
-        unsafe {
-            Ok(peripheral
-                .maximumWriteValueLengthForType(CBCharacteristicWriteType::WithoutResponse))
-        }
+        self.inner.dispatch(|characteristic| {
+            let peripheral =
+                unsafe { characteristic.service().and_then(|x| x.peripheral()) }.ok_or(
+                    Error::new(ErrorKind::NotFound, None, "peripheral not found"),
+                )?;
+            unsafe {
+                Ok(peripheral
+                    .maximumWriteValueLengthForType(CBCharacteristicWriteType::WithoutResponse))
+            }
+        })
     }
 
     /// Get the maximum amount of data that can be written in a single packet for this characteristic.
@@ -256,27 +292,36 @@ impl CharacteristicImpl {
             ));
         };
 
-        let service = unsafe { self.inner.service() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "service not found",
-        ))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        let service = self.inner.dispatch(|characteristic| {
+            let service = unsafe { characteristic.service() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "service not found",
+            ))?;
+            let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "peripheral not found",
+            ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
-
-        unsafe { peripheral.setNotifyValue_forCharacteristic(true, &self.inner) };
-        let guard = defer(move || {
-            if let Some(peripheral) = unsafe { self.inner.service().and_then(|x| x.peripheral()) } {
-                unsafe { peripheral.setNotifyValue_forCharacteristic(false, &self.inner) };
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
             }
+
+            unsafe { peripheral.setNotifyValue_forCharacteristic(true, characteristic) };
+
+            Ok(unsafe { Dispatched::new(service) })
+        })?;
+
+        let guard = defer(move || {
+            self.inner.dispatch(|characteristic| {
+                if let Some(peripheral) =
+                    unsafe { characteristic.service().and_then(|x| x.peripheral()) }
+                {
+                    unsafe { peripheral.setNotifyValue_forCharacteristic(false, characteristic) };
+                }
+            });
         });
 
         loop {
@@ -310,10 +355,7 @@ impl CharacteristicImpl {
                         error,
                     } if characteristic == self.inner => match error {
                         Some(err) => Some(Err(Error::from_nserror(err))),
-                        None => {
-                            let data = data.map(|val| val.to_vec()).unwrap_or_default();
-                            Some(Ok(data))
-                        }
+                        None => Some(Ok(data)),
                     },
                     PeripheralEvent::Disconnected { error } => Some(Err(
                         Error::from_kind_and_nserror(ErrorKind::NotConnected, error),
@@ -340,28 +382,33 @@ impl CharacteristicImpl {
 
     /// Is the device currently sending notifications for this characteristic?
     pub async fn is_notifying(&self) -> Result<bool> {
-        Ok(unsafe { self.inner.isNotifying() })
+        Ok(self
+            .inner
+            .dispatch(|characteristic| unsafe { characteristic.isNotifying() }))
     }
 
     /// Discover the descriptors associated with this characteristic.
     pub async fn discover_descriptors(&self) -> Result<Vec<Descriptor>> {
-        let service = unsafe { self.inner.service() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "service not found",
-        ))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        let service = self.inner.dispatch(|characteristic| {
+            let service = unsafe { characteristic.service() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "service not found",
+            ))?;
+            let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "peripheral not found",
+            ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
 
-        unsafe { peripheral.discoverDescriptorsForCharacteristic(&self.inner) }
+            unsafe { peripheral.discoverDescriptorsForCharacteristic(characteristic) }
+            Ok(unsafe { Dispatched::new(service) })
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {
@@ -398,18 +445,20 @@ impl CharacteristicImpl {
     }
 
     fn descriptors_inner(&self) -> Result<Vec<Descriptor>> {
-        unsafe { self.inner.descriptors() }
-            .map(|s| {
-                s.iter()
-                    .map(|x| Descriptor::new(&x, self.delegate.clone()))
-                    .collect()
-            })
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::NotReady,
-                    None,
-                    "no descriptors have been discovered",
-                )
-            })
+        self.inner.dispatch(|characteristic| {
+            unsafe { characteristic.descriptors() }
+                .map(|s| {
+                    s.iter()
+                        .map(|x| Descriptor::new(x, self.delegate.clone()))
+                        .collect()
+                })
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::NotReady,
+                        None,
+                        "no descriptors have been discovered",
+                    )
+                })
+        })
     }
 }

--- a/src/corebluetooth/delegates.rs
+++ b/src/corebluetooth/delegates.rs
@@ -1,35 +1,38 @@
-#![allow(unused_variables)]
 use objc2::rc::Retained;
-use objc2::{AnyThread, DefinedClass, Message, define_class, msg_send};
+use objc2::{define_class, msg_send, AnyThread, DefinedClass, Message};
 use objc2_core_bluetooth::{
     CBCentralManager, CBCentralManagerDelegate, CBCharacteristic, CBConnectionEvent, CBDescriptor,
     CBL2CAPChannel, CBPeripheral, CBPeripheralDelegate, CBService,
 };
 use objc2_foundation::{
-    NSArray, NSData, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSString,
+    NSArray, NSDictionary, NSError, NSNumber, NSObject, NSObjectProtocol, NSString,
 };
-use tracing::{debug, error};
+use tracing::debug;
+
+use crate::AdvertisementData;
+
+use super::dispatch::Dispatched;
 
 #[derive(Clone)]
 pub enum CentralEvent {
     Connect {
-        peripheral: Retained<CBPeripheral>,
+        peripheral: Dispatched<CBPeripheral>,
     },
     Disconnect {
-        peripheral: Retained<CBPeripheral>,
+        peripheral: Dispatched<CBPeripheral>,
         error: Option<Retained<NSError>>,
     },
     ConnectFailed {
-        peripheral: Retained<CBPeripheral>,
+        peripheral: Dispatched<CBPeripheral>,
         error: Option<Retained<NSError>>,
     },
     ConnectionEvent {
-        peripheral: Retained<CBPeripheral>,
+        peripheral: Dispatched<CBPeripheral>,
         event: CBConnectionEvent,
     },
     Discovered {
-        peripheral: Retained<CBPeripheral>,
-        adv_data: Retained<NSDictionary<NSString>>,
+        peripheral: Dispatched<CBPeripheral>,
+        adv_data: AdvertisementData,
         rssi: i16,
     },
     StateChanged,
@@ -79,37 +82,37 @@ pub enum PeripheralEvent {
         error: Option<Retained<NSError>>,
     },
     DiscoveredIncludedServices {
-        service: Retained<CBService>,
+        service: Dispatched<CBService>,
         error: Option<Retained<NSError>>,
     },
     DiscoveredCharacteristics {
-        service: Retained<CBService>,
+        service: Dispatched<CBService>,
         error: Option<Retained<NSError>>,
     },
     DiscoveredDescriptors {
-        characteristic: Retained<CBCharacteristic>,
+        characteristic: Dispatched<CBCharacteristic>,
         error: Option<Retained<NSError>>,
     },
     CharacteristicValueUpdate {
-        characteristic: Retained<CBCharacteristic>,
-        data: Option<Retained<NSData>>,
+        characteristic: Dispatched<CBCharacteristic>,
+        data: Vec<u8>,
         error: Option<Retained<NSError>>,
     },
     DescriptorValueUpdate {
-        descriptor: Retained<CBDescriptor>,
+        descriptor: Dispatched<CBDescriptor>,
         error: Option<Retained<NSError>>,
     },
     CharacteristicValueWrite {
-        characteristic: Retained<CBCharacteristic>,
+        characteristic: Dispatched<CBCharacteristic>,
         error: Option<Retained<NSError>>,
     },
     DescriptorValueWrite {
-        descriptor: Retained<CBDescriptor>,
+        descriptor: Dispatched<CBDescriptor>,
         error: Option<Retained<NSError>>,
     },
     ReadyToWrite,
     NotificationStateUpdate {
-        characteristic: Retained<CBCharacteristic>,
+        characteristic: Dispatched<CBCharacteristic>,
         error: Option<Retained<NSError>>,
     },
     ReadRssi {
@@ -118,11 +121,11 @@ pub enum PeripheralEvent {
     },
     NameUpdate,
     ServicesChanged {
-        invalidated_services: Vec<Retained<CBService>>,
+        invalidated_services: Vec<Dispatched<CBService>>,
     },
     #[allow(unused)]
     L2CAPChannelOpened {
-        channel: Retained<CBL2CAPChannel>,
+        channel: Dispatched<CBL2CAPChannel>,
         error: Option<Retained<NSError>>,
     },
 }
@@ -143,7 +146,7 @@ define_class!(
 
     unsafe impl CBCentralManagerDelegate for CentralDelegate {
         #[unsafe(method(centralManagerDidUpdateState:))]
-        fn did_update_state(&self, central: &CBCentralManager) {
+        fn did_update_state(&self, _central: &CBCentralManager) {
             let _ = self
                 .ivars()
                 .sender
@@ -151,18 +154,17 @@ define_class!(
         }
 
         #[unsafe(method(centralManager:didConnectPeripheral:))]
-        fn did_connect_peripheral(&self, central: &CBCentralManager, peripheral: &CBPeripheral) {
+        fn did_connect_peripheral(&self, _central: &CBCentralManager, peripheral: &CBPeripheral) {
             let sender = &self.ivars().sender;
             unsafe {
                 if let Some(delegate) = peripheral
                     .delegate()
-                    .map(|d| d.downcast::<PeripheralDelegate>().ok())
-                    .flatten()
+                    .and_then(|d| d.downcast::<PeripheralDelegate>().ok())
                 {
                     let _res = delegate.sender().try_broadcast(PeripheralEvent::Connected);
                 }
                 let event = CentralEvent::Connect {
-                    peripheral: peripheral.retain(),
+                    peripheral: Dispatched::retain(peripheral),
                 };
                 debug!("CentralDelegate received {:?}", event);
                 let _ = sender.try_broadcast(event);
@@ -172,7 +174,7 @@ define_class!(
         #[unsafe(method(centralManager:didDisconnectPeripheral:error:))]
         fn did_disconnect_peripheral_error(
             &self,
-            central: &CBCentralManager,
+            _central: &CBCentralManager,
             peripheral: &CBPeripheral,
             error: Option<&NSError>,
         ) {
@@ -180,8 +182,7 @@ define_class!(
                 let sender = &self.ivars().sender;
                 if let Some(delegate) = peripheral
                     .delegate()
-                    .map(|d| d.downcast::<PeripheralDelegate>().ok())
-                    .flatten()
+                    .and_then(|d| d.downcast::<PeripheralDelegate>().ok())
                 {
                     let _res = delegate
                         .sender()
@@ -190,7 +191,7 @@ define_class!(
                         });
                 }
                 let event = CentralEvent::Disconnect {
-                    peripheral: peripheral.retain(),
+                    peripheral: Dispatched::retain(peripheral),
                     error: error.map(|e| e.retain()),
                 };
                 debug!("CentralDelegate received {:?}", event);
@@ -201,7 +202,7 @@ define_class!(
         #[unsafe(method(centralManager:didDiscoverPeripheral:advertisementData:RSSI:))]
         fn did_discover_peripheral(
             &self,
-            central: &CBCentralManager,
+            _central: &CBCentralManager,
             peripheral: &CBPeripheral,
             adv_data: &NSDictionary<NSString>,
             rssi: &NSNumber,
@@ -209,8 +210,8 @@ define_class!(
             let sender = &self.ivars().sender;
             let rssi: i16 = rssi.shortValue();
             let event = CentralEvent::Discovered {
-                peripheral: peripheral.retain(),
-                adv_data: adv_data.retain(),
+                peripheral: unsafe { Dispatched::retain(peripheral) },
+                adv_data: AdvertisementData::from_nsdictionary(adv_data),
                 rssi,
             };
             debug!("CentralDelegate received {:?}", event);
@@ -220,30 +221,23 @@ define_class!(
         #[unsafe(method(centralManager:connectionEventDidOccur:forPeripheral:))]
         fn on_connection_event(
             &self,
-            central: &CBCentralManager,
+            _central: &CBCentralManager,
             event: CBConnectionEvent,
             peripheral: &CBPeripheral,
         ) {
             let sender = &self.ivars().sender;
-            match event.try_into() {
-                Ok(event) => {
-                    let event = CentralEvent::ConnectionEvent {
-                        peripheral: peripheral.retain(),
-                        event,
-                    };
-                    debug!("CentralDelegate received {:?}", event);
-                    let _res = sender.try_broadcast(event);
-                }
-                Err(err) => {
-                    error!("Invalid value for CBConnectionEvent: {}", err);
-                }
-            }
+            let event = CentralEvent::ConnectionEvent {
+                peripheral: unsafe { Dispatched::retain(peripheral) },
+                event,
+            };
+            debug!("CentralDelegate received {:?}", event);
+            let _res = sender.try_broadcast(event);
         }
 
         #[unsafe(method(centralManager:didFailToConnectPeripheral:error:))]
         fn did_fail_to_connect(
             &self,
-            central: &CBCentralManager,
+            _central: &CBCentralManager,
             peripheral: &CBPeripheral,
             error: Option<&NSError>,
         ) {
@@ -251,7 +245,7 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(CentralEvent::ConnectFailed {
-                    peripheral: peripheral.retain(),
+                    peripheral: unsafe { Dispatched::retain(peripheral) },
                     error: error.map(|e| e.retain()),
                 });
         }
@@ -295,15 +289,18 @@ define_class!(
         #[unsafe(method(peripheral:didUpdateValueForCharacteristic:error:))]
         fn did_update_value_for_characteristic_error(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             characteristic: &CBCharacteristic,
             error: Option<&NSError>,
         ) {
             unsafe {
                 let sender = &self.ivars().sender;
-                let data = characteristic.value();
+                let data = characteristic
+                    .value()
+                    .map(|x| x.as_bytes_unchecked().to_vec())
+                    .unwrap_or_default();
                 let event = PeripheralEvent::CharacteristicValueUpdate {
-                    characteristic: characteristic.retain(),
+                    characteristic: Dispatched::retain(characteristic),
                     data,
                     error: error.map(|e| e.retain()),
                 };
@@ -313,7 +310,7 @@ define_class!(
         }
 
         #[unsafe(method(peripheral:didDiscoverServices:))]
-        fn did_discover_services(&self, peripheral: &CBPeripheral, error: Option<&NSError>) {
+        fn did_discover_services(&self, _peripheral: &CBPeripheral, error: Option<&NSError>) {
             let _ = self
                 .ivars()
                 .sender
@@ -325,7 +322,7 @@ define_class!(
         #[unsafe(method(peripheral:didDiscoverIncludedServicesForService:error:))]
         fn did_discover_included_services(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             service: &CBService,
             error: Option<&NSError>,
         ) {
@@ -333,13 +330,13 @@ define_class!(
                 self.ivars()
                     .sender
                     .try_broadcast(PeripheralEvent::DiscoveredIncludedServices {
-                        service: service.retain(),
+                        service: unsafe { Dispatched::retain(service) },
                         error: error.map(|e| e.retain()),
                     });
         }
 
         #[unsafe(method(peripheralDidUpdateName:))]
-        fn did_update_name(&self, peripheral: &CBPeripheral) {
+        fn did_update_name(&self, _peripheral: &CBPeripheral) {
             let _ = self
                 .ivars()
                 .sender
@@ -349,24 +346,29 @@ define_class!(
         #[unsafe(method(peripheral:didModifyServices:))]
         fn did_modify_services(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             invalidated_services: &NSArray<CBService>,
         ) {
+            let invalidated_services = invalidated_services
+                .iter()
+                .map(|x| unsafe { Dispatched::new(x) })
+                .collect();
+
             let _ = self
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::ServicesChanged {
-                    invalidated_services: invalidated_services.to_vec(),
+                    invalidated_services,
                 });
         }
 
         #[unsafe(method(peripheralDidUpdateRSSI:error:))]
-        fn did_update_rssi(&self, peripheral: &CBPeripheral, error: Option<&NSError>) {}
+        fn did_update_rssi(&self, _peripheral: &CBPeripheral, _error: Option<&NSError>) {}
 
         #[unsafe(method(peripheral:didReadRSSI:error:))]
         fn did_read_rssi(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             rssi: &NSNumber,
             error: Option<&NSError>,
         ) {
@@ -382,7 +384,7 @@ define_class!(
         #[unsafe(method(peripheral:didDiscoverCharacteristicsForService:error:))]
         fn did_discover_characteristics_for_service(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             service: &CBService,
             error: Option<&NSError>,
         ) {
@@ -390,7 +392,7 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::DiscoveredCharacteristics {
-                    service: service.retain(),
+                    service: unsafe { Dispatched::retain(service) },
                     error: error.map(|e| e.retain()),
                 });
         }
@@ -398,7 +400,7 @@ define_class!(
         #[unsafe(method(peripheral:didWriteValueForCharacteristic:error:))]
         fn did_write_value_for_characteristic(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             characteristic: &CBCharacteristic,
             error: Option<&NSError>,
         ) {
@@ -406,7 +408,7 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::CharacteristicValueWrite {
-                    characteristic: characteristic.retain(),
+                    characteristic: unsafe { Dispatched::retain(characteristic) },
                     error: error.map(|e| e.retain()),
                 });
         }
@@ -414,7 +416,7 @@ define_class!(
         #[unsafe(method(peripheral:didUpdateNotificationStateForCharacteristic:error:))]
         fn did_update_notification_state_for_characteristic(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             characteristic: &CBCharacteristic,
             error: Option<&NSError>,
         ) {
@@ -422,7 +424,7 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::NotificationStateUpdate {
-                    characteristic: characteristic.retain(),
+                    characteristic: unsafe { Dispatched::retain(characteristic) },
                     error: error.map(|e| e.retain()),
                 });
         }
@@ -430,7 +432,7 @@ define_class!(
         #[unsafe(method(peripheral:didDiscoverDescriptorsForCharacteristic:error:))]
         fn did_discover_descriptors_for_characteristic(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             characteristic: &CBCharacteristic,
             error: Option<&NSError>,
         ) {
@@ -438,7 +440,7 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::DiscoveredDescriptors {
-                    characteristic: characteristic.retain(),
+                    characteristic: unsafe { Dispatched::retain(characteristic) },
                     error: error.map(|e| e.retain()),
                 });
         }
@@ -446,7 +448,7 @@ define_class!(
         #[unsafe(method(peripheral:didUpdateValueForDescriptor:error:))]
         fn did_update_value_for_descriptor(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             descriptor: &CBDescriptor,
             error: Option<&NSError>,
         ) {
@@ -454,7 +456,7 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::DescriptorValueUpdate {
-                    descriptor: descriptor.retain(),
+                    descriptor: unsafe { Dispatched::retain(descriptor) },
                     error: error.map(|e| e.retain()),
                 });
         }
@@ -462,7 +464,7 @@ define_class!(
         #[unsafe(method(peripheral:didWriteValueForDescriptor:error:))]
         fn did_write_value_for_descriptor(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             descriptor: &CBDescriptor,
             error: Option<&NSError>,
         ) {
@@ -470,13 +472,13 @@ define_class!(
                 .ivars()
                 .sender
                 .try_broadcast(PeripheralEvent::DescriptorValueWrite {
-                    descriptor: descriptor.retain(),
+                    descriptor: unsafe { Dispatched::retain(descriptor) },
                     error: error.map(|e| e.retain()),
                 });
         }
 
         #[unsafe(method(peripheralIsReadyToSendWriteWithoutResponse:))]
-        fn is_ready_to_write_without_response(&self, peripheral: &CBPeripheral) {
+        fn is_ready_to_write_without_response(&self, _peripheral: &CBPeripheral) {
             let _ = self
                 .ivars()
                 .sender
@@ -486,7 +488,7 @@ define_class!(
         #[unsafe(method(peripheral:didOpenL2CAPChannel:error:))]
         fn did_open_l2cap_channel(
             &self,
-            peripheral: &CBPeripheral,
+            _peripheral: &CBPeripheral,
             channel: Option<&CBL2CAPChannel>,
             error: Option<&NSError>,
         ) {
@@ -495,7 +497,7 @@ define_class!(
                     .ivars()
                     .sender
                     .try_broadcast(PeripheralEvent::L2CAPChannelOpened {
-                        channel: channel.retain(),
+                        channel: unsafe { Dispatched::retain(channel) },
                         error: error.map(|e| e.retain()),
                     });
             }

--- a/src/corebluetooth/descriptor.rs
+++ b/src/corebluetooth/descriptor.rs
@@ -1,16 +1,17 @@
 use objc2::runtime::AnyObject;
-use objc2::{Message, msg_send, rc::Retained};
+use objc2::{msg_send, rc::Retained};
 use objc2_foundation::{NSData, NSNumber, NSString, NSUInteger};
 
 use super::delegates::{PeripheralDelegate, PeripheralEvent};
+use super::dispatch::Dispatched;
 use crate::error::ErrorKind;
-use crate::{Descriptor, Error, Result, Uuid};
+use crate::{BluetoothUuidExt, Descriptor, Error, Result, Uuid};
 use objc2_core_bluetooth::{CBDescriptor, CBPeripheralState};
 
 /// A Bluetooth GATT descriptor
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DescriptorImpl {
-    inner: Retained<CBDescriptor>,
+    inner: Dispatched<CBDescriptor>,
     delegate: Retained<PeripheralDelegate>,
 }
 
@@ -38,9 +39,12 @@ fn value_to_slice(val: &AnyObject) -> Vec<u8> {
 }
 
 impl Descriptor {
-    pub(super) fn new(descriptor: &CBDescriptor, delegate: Retained<PeripheralDelegate>) -> Self {
+    pub(super) fn new(
+        descriptor: Retained<CBDescriptor>,
+        delegate: Retained<PeripheralDelegate>,
+    ) -> Self {
         Descriptor(DescriptorImpl {
-            inner: descriptor.retain(),
+            inner: unsafe { Dispatched::new(descriptor) },
             delegate,
         })
     }
@@ -49,7 +53,9 @@ impl Descriptor {
 impl DescriptorImpl {
     /// The [`Uuid`] identifying the type of this GATT descriptor
     pub fn uuid(&self) -> Uuid {
-        unsafe { Uuid::from_slice(self.inner.UUID().data().as_bytes_unchecked()).unwrap() }
+        self.inner.dispatch(|descriptor| unsafe {
+            Uuid::from_bluetooth_bytes(descriptor.UUID().data().as_bytes_unchecked())
+        })
     }
 
     /// The [`Uuid`] identifying the type of this GATT descriptor
@@ -61,33 +67,40 @@ impl DescriptorImpl {
     ///
     /// If the value has not yet been read, this method may either return an error or perform a read of the value.
     pub async fn value(&self) -> Result<Vec<u8>> {
-        unsafe { self.inner.value() }
-            .map(|val| value_to_slice(&val))
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::NotReady,
-                    None,
-                    "the descriptor value has not been read",
-                )
-            })
+        self.inner.dispatch(|descriptor| unsafe {
+            descriptor
+                .value()
+                .map(|val| value_to_slice(&val))
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::NotReady,
+                        None,
+                        "the descriptor value has not been read",
+                    )
+                })
+        })
     }
 
     /// Read the value of this descriptor from the device
     pub async fn read(&self) -> Result<Vec<u8>> {
-        let service = unsafe { self.inner.characteristic().and_then(|x| x.service()) }
-            .ok_or(Error::new(ErrorKind::NotFound, None, "service not found"))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        let service = self.inner.dispatch(|descriptor| {
+            let service = unsafe { descriptor.characteristic().and_then(|x| x.service()) }
+                .ok_or(Error::new(ErrorKind::NotFound, None, "service not found"))?;
+            let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "peripheral not found",
+            ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
 
-        unsafe { peripheral.readValueForDescriptor(&self.inner) };
+            unsafe { peripheral.readValueForDescriptor(descriptor) };
+
+            Ok(unsafe { Dispatched::new(service) })
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {
@@ -114,21 +127,24 @@ impl DescriptorImpl {
 
     /// Write the value of this descriptor on the device to `value`
     pub async fn write(&self, value: &[u8]) -> Result<()> {
-        let service = unsafe { self.inner.characteristic().and_then(|x| x.service()) }
-            .ok_or(Error::new(ErrorKind::NotFound, None, "service not found"))?;
-        let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
-            ErrorKind::NotFound,
-            None,
-            "peripheral not found",
-        ))?;
         let mut receiver = self.delegate.sender().new_receiver();
+        let service = self.inner.dispatch(|descriptor| {
+            let service = unsafe { descriptor.characteristic().and_then(|x| x.service()) }
+                .ok_or(Error::new(ErrorKind::NotFound, None, "service not found"))?;
+            let peripheral = unsafe { service.peripheral() }.ok_or(Error::new(
+                ErrorKind::NotFound,
+                None,
+                "peripheral not found",
+            ))?;
 
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
 
-        let data = NSData::with_bytes(value);
-        unsafe { peripheral.writeValue_forDescriptor(&data, &self.inner) };
+            let data = NSData::with_bytes(value);
+            unsafe { peripheral.writeValue_forDescriptor(&data, descriptor) };
+            Ok(unsafe { Dispatched::new(service) })
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {

--- a/src/corebluetooth/device.rs
+++ b/src/corebluetooth/device.rs
@@ -58,20 +58,18 @@ impl std::fmt::Display for DeviceImpl {
 }
 
 impl Device {
-    pub(super) fn new(peripheral: Dispatched<CBPeripheral>) -> Self {
-        let delegate = peripheral.dispatch(|peripheral| {
-            let delegate = unsafe { peripheral.delegate() }.unwrap_or_else(|| {
-                // Create a new delegate and attach it to the peripheral
-                let delegate = ProtocolObject::from_retained(PeripheralDelegate::new());
-                unsafe { peripheral.setDelegate(Some(&delegate)) }
-                delegate
-            });
-
-            delegate.downcast().unwrap()
+    pub(super) fn new(peripheral: Retained<CBPeripheral>) -> Self {
+        let delegate = unsafe { peripheral.delegate() }.unwrap_or_else(|| {
+            // Create a new delegate and attach it to the peripheral
+            let delegate = ProtocolObject::from_retained(PeripheralDelegate::new());
+            unsafe { peripheral.setDelegate(Some(&delegate)) }
+            delegate
         });
 
+        let delegate = delegate.downcast().unwrap();
+
         Device(DeviceImpl {
-            peripheral,
+            peripheral: unsafe { Dispatched::new(peripheral) },
             delegate,
         })
     }

--- a/src/corebluetooth/dispatch.rs
+++ b/src/corebluetooth/dispatch.rs
@@ -1,0 +1,96 @@
+use std::cell::UnsafeCell;
+use std::hash::{Hash, Hasher};
+use std::mem::MaybeUninit;
+use std::sync::OnceLock;
+
+use dispatch2::{DispatchQoS, DispatchQueue, DispatchQueueAttr, DispatchRetained};
+use objc2::rc::Retained;
+use objc2::Message;
+
+/// Get a serial dispatch queue to use for all CoreBluetooth operations
+pub(crate) fn queue() -> &'static DispatchQueue {
+    static CELL: OnceLock<DispatchRetained<DispatchQueue>> = OnceLock::new();
+    CELL.get_or_init(|| {
+        let utility = DispatchQueue::global_queue(
+            dispatch2::GlobalQueueIdentifier::QualityOfService(DispatchQoS::Utility),
+        );
+        DispatchQueue::new_with_target("Bluest", DispatchQueueAttr::SERIAL, Some(&utility))
+    })
+}
+
+/// Synchronizes access to an Objective-C object by restricting all access to occur
+/// within the context of a single global serial dispatch queue.
+///
+/// This allows !Send / !Sync Objective-C types to be used from multiple Rust threads.
+#[derive(Debug)]
+pub(crate) struct Dispatched<T>(UnsafeCell<Retained<T>>);
+
+unsafe impl<T> Send for Dispatched<T> {}
+unsafe impl<T> Sync for Dispatched<T> {}
+
+impl<T: Message> Clone for Dispatched<T> {
+    fn clone(&self) -> Self {
+        unsafe { Dispatched::retain(&**self.0.get()) }
+    }
+}
+
+impl<T: PartialEq<T>> PartialEq<Dispatched<T>> for Dispatched<T> {
+    fn eq(&self, other: &Dispatched<T>) -> bool {
+        self.dispatch(|val| (*val).eq(unsafe { other.get() }))
+    }
+}
+
+impl<T: Hash> Hash for Dispatched<T> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Hasher may not be Send, so we hash our internal value using `DefaultHasher`
+        // then add that hash value to `state`
+        self.dispatch(|val| {
+            let mut state = std::hash::DefaultHasher::new();
+            val.hash(&mut state);
+            state.finish()
+        })
+        .hash(state)
+    }
+}
+
+impl<T: Eq> Eq for Dispatched<T> {}
+
+impl<T> Dispatched<T> {
+    /// # Safety
+    ///
+    /// - It must be safe to access `value` from the context of [`queue()`].
+    /// - After calling `new`, `value` must only be accessed from within the context of `queue()`.
+    pub unsafe fn new(value: Retained<T>) -> Self {
+        Self(UnsafeCell::new(value))
+    }
+
+    /// # Safety
+    ///
+    /// - It must be safe to access `value` from the context of [`queue()`].
+    /// - After calling `retain`, `value` must only be accessed from within the context of `queue()`.
+    pub unsafe fn retain(value: &T) -> Self
+    where
+        T: Message,
+    {
+        Self(UnsafeCell::new(value.retain()))
+    }
+
+    pub fn dispatch<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&T) -> R + Send,
+        R: Send,
+    {
+        let mut ret = MaybeUninit::uninit();
+        queue().exec_sync(|| {
+            ret.write((f)(unsafe { self.get() }));
+        });
+        unsafe { ret.assume_init() }
+    }
+
+    /// # Safety
+    ///
+    /// This method must only be called from within the context of `queue()`.
+    pub unsafe fn get(&self) -> &T {
+        &*self.0.get()
+    }
+}

--- a/src/corebluetooth/service.rs
+++ b/src/corebluetooth/service.rs
@@ -1,23 +1,26 @@
-use objc2::Message;
 use objc2::rc::Retained;
 use objc2_foundation::{NSArray, NSData};
 
 use super::delegates::{PeripheralDelegate, PeripheralEvent};
+use super::dispatch::Dispatched;
 use crate::error::ErrorKind;
-use crate::{Characteristic, Error, Result, Service, Uuid};
+use crate::{BluetoothUuidExt, Characteristic, Error, Result, Service, Uuid};
 use objc2_core_bluetooth::{CBPeripheralState, CBService, CBUUID};
 
 /// A Bluetooth GATT service
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ServiceImpl {
-    pub(super) inner: Retained<CBService>,
+    pub(super) inner: Dispatched<CBService>,
     delegate: Retained<PeripheralDelegate>,
 }
 
 impl Service {
-    pub(super) fn new(service: &CBService, delegate: Retained<PeripheralDelegate>) -> Self {
+    pub(super) fn new(
+        service: Retained<CBService>,
+        delegate: Retained<PeripheralDelegate>,
+    ) -> Self {
         Service(ServiceImpl {
-            inner: service.retain(),
+            inner: unsafe { Dispatched::new(service) },
             delegate,
         })
     }
@@ -26,7 +29,9 @@ impl Service {
 impl ServiceImpl {
     /// The [`Uuid`] identifying the type of this GATT service
     pub fn uuid(&self) -> Uuid {
-        unsafe { Uuid::from_slice(self.inner.UUID().data().as_bytes_unchecked()).unwrap() }
+        self.inner.dispatch(|service| unsafe {
+            Uuid::from_bluetooth_bytes(service.UUID().data().as_bytes_unchecked())
+        })
     }
 
     /// The [`Uuid`] identifying the type of this GATT service
@@ -36,7 +41,8 @@ impl ServiceImpl {
 
     /// Whether this is a primary service of the device.
     pub async fn is_primary(&self) -> Result<bool> {
-        unsafe { Ok(self.inner.isPrimary()) }
+        self.inner
+            .dispatch(|service| unsafe { Ok(service.isPrimary()) })
     }
 
     /// Discover all characteristics associated with this service.
@@ -49,13 +55,7 @@ impl ServiceImpl {
         &self,
         uuid: Uuid,
     ) -> Result<Vec<Characteristic>> {
-        let uuids = unsafe {
-            NSArray::from_retained_slice(&[CBUUID::UUIDWithData(&NSData::with_bytes(
-                &uuid.as_bytes()[..],
-            ))])
-        };
-
-        let characteristics = self.discover_characteristics_inner(Some(&uuids)).await?;
+        let characteristics = self.discover_characteristics_inner(Some(uuid)).await?;
         Ok(characteristics
             .into_iter()
             .filter(|x| x.uuid() == uuid)
@@ -64,22 +64,31 @@ impl ServiceImpl {
 
     async fn discover_characteristics_inner(
         &self,
-        uuids: Option<&NSArray<CBUUID>>,
+        uuid: Option<Uuid>,
     ) -> Result<Vec<Characteristic>> {
-        let peripheral = unsafe {
-            self.inner.peripheral().ok_or(Error::new(
-                ErrorKind::NotFound,
-                None,
-                "peripheral not found",
-            ))?
-        };
-
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
-
         let mut receiver = self.delegate.sender().new_receiver();
-        unsafe { peripheral.discoverCharacteristics_forService(uuids, &self.inner) };
+        self.inner.dispatch(|service| {
+            let uuids = uuid.map(|uuid| unsafe {
+                NSArray::from_retained_slice(&[CBUUID::UUIDWithData(&NSData::with_bytes(
+                    &uuid.as_bytes()[..],
+                ))])
+            });
+
+            let peripheral = unsafe {
+                service.peripheral().ok_or(Error::new(
+                    ErrorKind::NotFound,
+                    None,
+                    "peripheral not found",
+                ))?
+            };
+
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
+
+            unsafe { peripheral.discoverCharacteristics_forService(uuids.as_deref(), service) };
+            Ok(())
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {
@@ -117,19 +126,21 @@ impl ServiceImpl {
     }
 
     fn characteristics_inner(&self) -> Result<Vec<Characteristic>> {
-        unsafe { self.inner.characteristics() }
-            .map(|s| {
-                s.iter()
-                    .map(|x| Characteristic::new(&x, self.delegate.clone()))
-                    .collect()
-            })
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::NotReady,
-                    None,
-                    "no characteristics have been discovered",
-                )
-            })
+        self.inner.dispatch(|service| {
+            unsafe { service.characteristics() }
+                .map(|s| {
+                    s.iter()
+                        .map(|x| Characteristic::new(x, self.delegate.clone()))
+                        .collect()
+                })
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::NotReady,
+                        None,
+                        "no characteristics have been discovered",
+                    )
+                })
+        })
     }
 
     /// Discover the included services of this service.
@@ -139,34 +150,34 @@ impl ServiceImpl {
 
     /// Discover the included service(s) with the given [`Uuid`].
     pub async fn discover_included_services_with_uuid(&self, uuid: Uuid) -> Result<Vec<Service>> {
-        let uuids = unsafe {
-            NSArray::from_retained_slice(&[CBUUID::UUIDWithData(&NSData::with_bytes(
-                &uuid.as_bytes()[..],
-            ))])
-        };
-
-        let services = self.discover_included_services_inner(Some(&uuids)).await?;
+        let services = self.discover_included_services_inner(Some(uuid)).await?;
         Ok(services.into_iter().filter(|x| x.uuid() == uuid).collect())
     }
 
-    async fn discover_included_services_inner(
-        &self,
-        uuids: Option<&NSArray<CBUUID>>,
-    ) -> Result<Vec<Service>> {
-        let peripheral = unsafe {
-            self.inner.peripheral().ok_or(Error::new(
-                ErrorKind::NotFound,
-                None,
-                "peripheral not found",
-            ))?
-        };
-
-        if unsafe { peripheral.state() } != CBPeripheralState::Connected {
-            return Err(ErrorKind::NotConnected.into());
-        }
-
+    async fn discover_included_services_inner(&self, uuid: Option<Uuid>) -> Result<Vec<Service>> {
         let mut receiver = self.delegate.sender().new_receiver();
-        unsafe { peripheral.discoverIncludedServices_forService(uuids, &self.inner) };
+        self.inner.dispatch(|service| {
+            let uuids = uuid.map(|uuid| unsafe {
+                NSArray::from_retained_slice(&[CBUUID::UUIDWithData(&NSData::with_bytes(
+                    &uuid.as_bytes()[..],
+                ))])
+            });
+
+            let peripheral = unsafe {
+                service.peripheral().ok_or(Error::new(
+                    ErrorKind::NotFound,
+                    None,
+                    "peripheral not found",
+                ))?
+            };
+
+            if unsafe { peripheral.state() } != CBPeripheralState::Connected {
+                return Err(Error::from(ErrorKind::NotConnected));
+            }
+
+            unsafe { peripheral.discoverIncludedServices_forService(uuids.as_deref(), service) };
+            Ok(())
+        })?;
 
         loop {
             match receiver.recv().await.map_err(Error::from_recv_error)? {
@@ -204,18 +215,20 @@ impl ServiceImpl {
     }
 
     fn included_services_inner(&self) -> Result<Vec<Service>> {
-        unsafe { self.inner.includedServices() }
-            .map(|s| {
-                s.iter()
-                    .map(|x| Service::new(&x, self.delegate.clone()))
-                    .collect()
-            })
-            .ok_or_else(|| {
-                Error::new(
-                    ErrorKind::NotReady,
-                    None,
-                    "no included services have been discovered",
-                )
-            })
+        self.inner.dispatch(|service| {
+            unsafe { service.includedServices() }
+                .map(|s| {
+                    s.iter()
+                        .map(|x| Service::new(x, self.delegate.clone()))
+                        .collect()
+                })
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::NotReady,
+                        None,
+                        "no included services have been discovered",
+                    )
+                })
+        })
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -141,7 +141,7 @@ impl Device {
     #[inline]
     pub async fn service_changed_indications(
         &self,
-    ) -> Result<impl Stream<Item = Result<ServicesChanged>> + Unpin + '_> {
+    ) -> Result<impl Stream<Item = Result<ServicesChanged>> + Send + Unpin + '_> {
         self.0.service_changed_indications().await
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,9 +144,9 @@ mod windows;
 
 use std::collections::HashMap;
 
-pub use adapter::Adapter;
 #[cfg(target_os = "linux")]
-pub use bluer::Uuid;
+pub use ::bluer::Uuid;
+pub use adapter::Adapter;
 pub use btuuid::BluetoothUuidExt;
 pub use characteristic::Characteristic;
 pub use descriptor::Descriptor;


### PR DESCRIPTION
Avoids possible data races by ensuring all CoreBluetooth object access is synchronized.